### PR TITLE
Use System.CommandLine for the CLI

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
     <packageSources>
         <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
+        <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
     </packageSources>
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />

--- a/source/XSharp.Compiler/Program.cs
+++ b/source/XSharp.Compiler/Program.cs
@@ -1,207 +1,204 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 
-namespace XSharp.DotNetCLI
+namespace XSharp.XSC
 {
-  internal class Program
-  {
-    private static void Main(string[] aArgs)
+    class Program
     {
-      try
-      {
-        // Parse arguments
-        var xCLI = new Build.CliProcessor();
-        xCLI.Parse(aArgs);
-
-        try
+        static void Main(string[] args)
         {
-          var xGen = new AsmGenerator();
-
-          bool xAppend = false;
-          string xOutputPath = null;
-
-          // Options
-          var xUserComments = xCLI["UserComments", "UC"];
-          if (xUserComments != null)
-          {
-            xGen.EmitUserComments = xUserComments.Check("ON", new string[] { "ON", "OFF" }) == "ON";
-          }
-          //
-          var xSourceCode = xCLI["SourceCode", "SC"];
-          if (xSourceCode != null)
-          {
-            xGen.EmitSourceCode = xSourceCode.Check("ON", new string[] { "ON", "OFF" }) == "ON";
-          }
-          //
-          var xOutput = xCLI["Out", "O"];
-          if (xOutput != null)
-          {
-            xOutputPath = xOutput.Value;
-          }
-          //
-          xAppend = xCLI["Append", "A"] != null;
-          if (xAppend && xOutput == null)
-          {
-            throw new Exception("Use of -Append requires use of -Out.");
-          }
-
-          // Plugins
-          var xPlugins = xCLI.GetSwitches("PlugIn");
-          foreach (var xPlugin in xPlugins)
-          {
-            // TODO Load plugins
-          }
-
-          // List of source files
-          var xFiles = new List<string>();
-          var xAssemblies = new List<Assembly>();
-          foreach (var xArg in xCLI.Args)
-          {
-            string xVal = xArg.Value;
-
-            if (Directory.Exists(xVal))
-            {
-              // If dir specified, find all .xs files
-              string xPath = Path.GetFullPath(xVal);
-              xFiles.AddRange(Directory.GetFiles(xPath, "*.xs"));
-            }
-            else if (File.Exists(xVal))
-            {
-              string xExt = Path.GetExtension(xVal).ToUpper();
-              if (xExt == ".XS")
-              {
-                xFiles.Add(Path.GetFullPath(xVal));
-              }
-              else if (xExt == ".DLL")
-              {
-                xAssemblies.Add(Assembly.ReflectionOnlyLoadFrom(xVal));
-              }
-              else
-              {
-                throw new Exception("Not a valid file type: " + xVal);
-              }
-            }
-            else
-            {
-              throw new Exception("Not a valid file or directory: " + xVal);
-            }
-          }
-
-          if (xCLI["Gen2"] != null)
-          {
-            foreach (var xFile in xFiles)
-            {
-              using (var xIn = File.OpenText(xFile))
-              {
-                if (!xAppend)
-                {
-                  xOutputPath = Path.ChangeExtension(xFile, ".asm");
-                }
-
-                using (var xOut = File.CreateText(xOutputPath))
-                {
-                  Console.WriteLine("Processing file: " + xFile);
-                  Compiler xCompiler;
-
-                  try
-                  {
-                    xCompiler = new Compiler(xOut);
-                  }
-                  catch (Exception e)
-                  {
-                    Console.WriteLine(e);
-                    throw;
-                  }
-                  try
-                  {
-                    xCompiler.Emit(xIn);
-                    var temp = Console.BackgroundColor;
-                    Console.BackgroundColor = ConsoleColor.Green;
-                    Console.WriteLine("File processed");
-                    Console.BackgroundColor = temp;
-                  }
-                  catch (Exception e)
-                  {
-                    var temp = Console.BackgroundColor;
-                    Console.BackgroundColor = ConsoleColor.Red;
-                    Console.WriteLine(e);
-                    Console.BackgroundColor = temp;
-                    throw;
-                  }
-                }
-              }
-            }
-          }
-          else
-          {
             try
             {
-              // Generate output
-              foreach (var xFile in xFiles)
-              {
-                var xReader = File.OpenText(xFile);
-                if (xAppend)
+                new CommandLineApplication().Execute(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Exception occurred:");
+                Console.WriteLine(ex);
+                Console.WriteLine("Press any key to exit...");
+                Console.ReadKey();
+            }
+        }
+    }
+
+    class CommandLineApplication
+    {
+        private bool mHelp;
+
+        private bool mGen2;
+        private bool mAppend;
+        private string mOutputPath;
+        private IReadOnlyList<string> mInputs;
+        private IReadOnlyList<string> mPlugins;
+
+        public void Execute(string[] args)
+        {
+            Console.WriteLine();
+
+            var xArgSyntax = ArgumentSyntax.Parse(args, (s) =>
+            {
+                s.ApplicationName = "xsc";
+                s.DefineOption("h|help", ref mHelp, "Display help");
+
+                s.DefineOption("gen2", ref mGen2, "Defines if the Gen2 of the compiler should be used.");
+                s.DefineOption("a|append", ref mAppend, "Defines if the compilation result should be written to a single file");
+                s.DefineOption("o|output", ref mOutputPath, "The output path");
+                s.DefineOptionList("p|plugins", ref mPlugins, "The plugins to load in the compiler");
+                s.DefineParameterList("source", ref mInputs, "The files to compile");
+            });
+
+            if (mHelp)
+            {
+                Console.WriteLine(xArgSyntax.GetHelpText());
+                return;
+            }
+
+            if (mAppend && mOutputPath == null)
+            {
+                throw new Exception("Use of --append requires use of --output.");
+            }
+
+            if (mPlugins != null)
+            {
+                foreach (var xPlugin in mPlugins)
                 {
-                  xGen.Generate(xReader, File.AppendText(xOutputPath));
+                    // TODO Load plugins
                 }
-                else if (xFiles.Count == 1 && xOutputPath != null)
+            }
+
+            // List of source files
+            var xFiles = new List<string>();
+            var xAssemblies = new List<Assembly>();
+            foreach (var xInput in mInputs)
+            {
+                if (Directory.Exists(xInput))
                 {
-                  xGen.Generate(File.OpenText(xFile), File.CreateText(xOutputPath));
+                    // If dir specified, find all .xs files
+                    string xPath = Path.GetFullPath(xInput);
+                    xFiles.AddRange(Directory.GetFiles(xPath, "*.xs"));
+                }
+                else if (File.Exists(xInput))
+                {
+                    string xExt = Path.GetExtension(xInput).ToLower();
+                    if (xExt == ".xs")
+                    {
+                        xFiles.Add(Path.GetFullPath(xInput));
+                    }
+                    else if (xExt == ".dll")
+                    {
+                        xAssemblies.Add(Assembly.ReflectionOnlyLoadFrom(xInput));
+                    }
+                    else
+                    {
+                        throw new Exception("Not a valid file type: " + xInput);
+                    }
                 }
                 else
                 {
-                  Console.WriteLine(xFile);
-                  xGen.GenerateToFiles(xFile);
+                    throw new Exception("Not a valid file or directory: " + xInput);
                 }
-              }
-
-              // Generate output from embedded resources
-              foreach (var xAssembly in xAssemblies)
-              {
-                TextWriter xWriter = null;
-                if (!xAppend)
-                {
-                  var xDestination = Path.ChangeExtension(xAssembly.Location, "asm");
-                  xWriter = new StreamWriter(File.Create(xDestination));
-                }
-
-                foreach (var xResource in xAssembly.GetManifestResourceNames()
-                  .Where(r => r.EndsWith(".xs", StringComparison.OrdinalIgnoreCase)))
-                {
-                  var xStream = xAssembly.GetManifestResourceStream(xResource);
-                  xGen.GenerateToFile(xResource, new StreamReader(xStream), xWriter);
-                }
-              }
             }
-            catch (Exception e)
+
+            if (mGen2)
             {
-              Console.WriteLine(e);
-            }
-          }
+                foreach (var xFile in xFiles)
+                {
+                    using (var xIn = File.OpenText(xFile))
+                    {
+                        if (!mAppend)
+                        {
+                            mOutputPath = Path.ChangeExtension(xFile, ".asm");
+                        }
 
-          // Finalize
-          Console.WriteLine("Done.");
+                        using (var xOut = File.CreateText(mOutputPath))
+                        {
+                            Console.WriteLine("Processing file: " + xFile);
+                            Compiler xCompiler;
+
+                            try
+                            {
+                                xCompiler = new Compiler(xOut);
+                            }
+                            catch (Exception e)
+                            {
+                                Console.WriteLine(e);
+                                throw;
+                            }
+                            try
+                            {
+                                xCompiler.Emit(xIn);
+                                var temp = Console.BackgroundColor;
+                                Console.BackgroundColor = ConsoleColor.Green;
+                                Console.WriteLine("File processed");
+                                Console.BackgroundColor = temp;
+                            }
+                            catch (Exception e)
+                            {
+                                var temp = Console.BackgroundColor;
+                                Console.BackgroundColor = ConsoleColor.Red;
+                                Console.WriteLine(e);
+                                Console.BackgroundColor = temp;
+                                throw;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                try
+                {
+                    var xGen = new AsmGenerator();
+
+                    // Generate output
+                    foreach (var xFile in xFiles)
+                    {
+                        var xReader = File.OpenText(xFile);
+                        if (mAppend)
+                        {
+                            xGen.Generate(xReader, File.AppendText(mOutputPath));
+                        }
+                        else if (xFiles.Count == 1 && mOutputPath != null)
+                        {
+                            xGen.Generate(File.OpenText(xFile), File.CreateText(mOutputPath));
+                        }
+                        else
+                        {
+                            Console.WriteLine(xFile);
+                            xGen.GenerateToFiles(xFile);
+                        }
+                    }
+
+                    // Generate output from embedded resources
+                    foreach (var xAssembly in xAssemblies)
+                    {
+                        TextWriter xWriter = null;
+                        if (!mAppend)
+                        {
+                            var xDestination = Path.ChangeExtension(xAssembly.Location, "asm");
+                            xWriter = new StreamWriter(File.Create(xDestination));
+                        }
+
+                        foreach (var xResource in xAssembly.GetManifestResourceNames()
+                          .Where(r => r.EndsWith(".xs", StringComparison.OrdinalIgnoreCase)))
+                        {
+                            var xStream = xAssembly.GetManifestResourceStream(xResource);
+                            xGen.GenerateToFile(xResource, new StreamReader(xStream), xWriter);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+            }
+
+            // Finalize
+            Console.WriteLine("Done.");
         }
-        catch (Exception ex)
-        {
-          if (xCLI["WaitOnError"] != null)
-          {
-            Console.WriteLine();
-            Console.WriteLine("Waiting on error. Press Enter to exit.");
-            Console.WriteLine("Exception: " + ex.ToString());
-            Console.ReadLine();
-          }
-          Environment.Exit(-1);
-        }
-      }
-      catch (Exception ex)
-      {
-        Console.WriteLine("Argument parse error:\r\n" + ex);
-        Environment.Exit(-2);
-      }
     }
-  }
 }

--- a/source/XSharp.Compiler/XSharp.Compiler.csproj
+++ b/source/XSharp.Compiler/XSharp.Compiler.csproj
@@ -28,6 +28,10 @@ $(XSharpDescription)</Description>
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="System.CommandLine" Version="0.1.0-e171004-2" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\XSharp.Assembler\XSharp.Assembler.csproj" />
         <ProjectReference Include="..\XSharp.Build\XSharp.Build.csproj" />
         <ProjectReference Include="..\XSharp\XSharp.csproj" />


### PR DESCRIPTION
## Changes
- Use System.CommandLine for the X# compiler CLI.

## Notes
- System.CommandLine is a pre-release package, in corefxlab (https://github.com/dotnet/corefxlab/tree/master/src/System.CommandLine), but it works well, it's easy to use and args work like the `dotnet` CLI.