### PR TITLE
Fix collisions when replacing illegal characters

### DIFF
--- a/source/XSharp/XSharp/Assembler/Gen1/DataMember.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/DataMember.cs
@@ -127,7 +127,14 @@ namespace XSharp.Assembler
             string xTempResult = aName;
             foreach (char c in IllegalIdentifierChars)
             {
-                xTempResult = xTempResult.Replace(c, '_');
+                if(c == '*') //  we need to replace * with a diffferent symbol otherwise we get collisions with Type** and Type[] resulting in the same string
+                {
+                    xTempResult = xTempResult.Replace(c, '#');
+                }
+                else
+                {
+                    xTempResult = xTempResult.Replace(c, '_');
+                }
             }
             return xTempResult;
         }


### PR DESCRIPTION
Currently Type** and Type[] would have the same label