### PR TITLE
Add option to disable formatting and comments

### DIFF
--- a/source/XSharp/XSharp/Assembler/Gen1/Assembler.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/Assembler.cs
@@ -14,9 +14,19 @@ namespace XSharp.Assembler
       mInstances.Push(this);
     }
 
-    public Assembler(bool addWhitespaceWhileFlushing) : this()
+    public Assembler(bool aFormat = false) : this()
     {
-      mAddWhitespaceWhileFlushing = addWhitespaceWhileFlushing;
+      Format = aFormat;
+      if (aFormat)
+      {
+          Separator = ", ";
+          AddSymbol = " + ";
+      }
+      else
+      {
+          Separator = ",";
+          AddSymbol = "+";
+      }
     }
 
     private static readonly Stack<Assembler> mInstances = new Stack<Assembler>();
@@ -217,7 +227,7 @@ namespace XSharp.Assembler
       aOutput.WriteLine();
       foreach (DataMember xMember in mDataMembers)
       {
-        if (mAddWhitespaceWhileFlushing)
+        if (Format)
         {
           aOutput.Write("\t");
         }
@@ -238,7 +248,7 @@ namespace XSharp.Assembler
       {
         var xOp = mInstructions[i];
         string prefix = null;
-        if (mAddWhitespaceWhileFlushing)
+        if (Format)
         {
           prefix = "\t\t\t";
         }
@@ -246,7 +256,7 @@ namespace XSharp.Assembler
         {
           var xLabel = (Label) xOp;
           aOutput.WriteLine();
-          if (mAddWhitespaceWhileFlushing)
+          if (Format)
           {
             prefix = "\t\t";
           }
@@ -265,7 +275,11 @@ namespace XSharp.Assembler
       aOutput.Flush();
     }
 
-    private bool mAddWhitespaceWhileFlushing = true;
+    public bool Format { get; }
+
+    public string Separator { get; }
+
+    public string AddSymbol { get; }
 
     protected virtual void BeforeFlushText(TextWriter aOutput)
     {

--- a/source/XSharp/XSharp/Assembler/Gen1/DataMember.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/DataMember.cs
@@ -43,7 +43,7 @@ namespace XSharp.Assembler
                 xBytes.CopyTo(xBytes2, 0);
                 xBytes2[xBytes2.Length - 1] = 0;
                 RawDefaultValue = xBytes2; StringValue = aValue;
-            } 
+            }
         }
 
         public DataMember(string aName, string aValue, Type aType)
@@ -170,14 +170,22 @@ namespace XSharp.Assembler
                 {
                     if (IsGlobal)
                     {
-                        aOutput.Write("\tglobal ");
+                        if (aAssembler.Format)
+                        {
+                            aOutput.Write('\t');
+                        }
+                        aOutput.Write("global ");
                         aOutput.WriteLine(Name);
 
                         if (AdditionalNames != null && AdditionalNames.Count() > 0)
                         {
                             foreach (var xName in AdditionalNames)
                             {
-                                aOutput.Write("\tglobal");
+                                if (aAssembler.Format)
+                                {
+                                    aOutput.Write('\t');
+                                }
+                                aOutput.Write("global");
                                 aOutput.WriteLine(xName);
                             }
                         }
@@ -189,15 +197,23 @@ namespace XSharp.Assembler
                     {
                         foreach(var xName in AdditionalNames)
                         {
-                            aOutput.WriteLine("\t" + xName + ":");
+                            if (aAssembler.Format)
+                            {
+                                aOutput.Write('\t');
+                            }
+                            aOutput.WriteLine(xName + ":");
                         }
                     }
 
-                    aOutput.Write("\t  db ");
+                    if (aAssembler.Format)
+                    {
+                        aOutput.Write("\t  ");
+                    }
+                    aOutput.Write("db ");
                     for (int i = 0; i < (RawDefaultValue.Length - 1); i++)
                     {
                         aOutput.Write(RawDefaultValue[i]);
-                        aOutput.Write(", ");
+                        aOutput.Write(aAssembler.Separator);
                     }
                     aOutput.Write(RawDefaultValue.Last());
                 }
@@ -212,7 +228,11 @@ namespace XSharp.Assembler
                         {
                             foreach (var xName in AdditionalNames)
                             {
-                                aOutput.Write("\tglobal");
+                                if (aAssembler.Format)
+                                {
+                                    aOutput.Write('\t');
+                                }
+                                aOutput.Write("global");
                                 aOutput.WriteLine(xName);
                             }
                         }
@@ -223,7 +243,11 @@ namespace XSharp.Assembler
                         aOutput.WriteLine(Name + ":");
                         foreach (var xName in AdditionalNames)
                         {
-                            aOutput.WriteLine("\t" + xName + ":");
+                            if (aAssembler.Format)
+                            {
+                                aOutput.Write('\t');
+                            }
+                            aOutput.WriteLine(xName + ":");
                         }
                     }
                     else
@@ -231,7 +255,11 @@ namespace XSharp.Assembler
                         aOutput.Write(Name + ":");
                     }
 
-                    aOutput.Write("\t  TIMES ");
+                    if (aAssembler.Format)
+                    {
+                        aOutput.Write("\t  ");
+                    }
+                    aOutput.Write("TIMES ");
                     aOutput.Write(RawDefaultValue.Length);
                     aOutput.Write($" {Size ?? "db"} ");
                     aOutput.Write(RawDefaultValue[0]);
@@ -260,12 +288,12 @@ namespace XSharp.Assembler
                                                            {
                                                                return xElementRef.Name;
                                                            }
-                                                           return xElementRef.Name + " + " + xElementRef.Offset;
+                                                           return xElementRef.Name + aAssembler.AddSymbol + xElementRef.Offset;
                                                        };
                 for (int i = 0; i < (UntypedDefaultValue.Length - 1); i++)
                 {
                     aOutput.Write(xGetTextForItem(UntypedDefaultValue[i]));
-                    aOutput.Write(", ");
+                    aOutput.Write(aAssembler.Separator);
                 }
                 aOutput.Write(xGetTextForItem(UntypedDefaultValue.Last()));
                 return;
@@ -279,7 +307,7 @@ namespace XSharp.Assembler
                     aOutput.Write(" ");
                     aOutput.Write(GetStringFromType(Type));
                     aOutput.Write(" ");
-                    aOutput.Write(StringValue);   
+                    aOutput.Write(StringValue);
                 }
                 else if (Size != null)
                 {

--- a/source/XSharp/XSharp/Assembler/Gen1/x86/SSEAndMMX2/InstructionWithDestinationAndSourceAndPseudoOpcodes.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/x86/SSEAndMMX2/InstructionWithDestinationAndSourceAndPseudoOpcodes.cs
@@ -12,9 +12,9 @@
             aOutput.Write(mMnemonic);
             aOutput.Write(" ");
             aOutput.Write(this.GetDestinationAsString());
-            aOutput.Write(", ");
+            aOutput.Write(aAssembler.Separator);
             aOutput.Write(this.GetSourceAsString());
-            aOutput.Write(", ");
+            aOutput.Write(aAssembler.Separator);
             aOutput.Write(this.pseudoOpcode);
         }
     }

--- a/source/XSharp/XSharp/Assembler/Gen1/x86/_Infra/InstructionWithDestinationAndSource.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/x86/_Infra/InstructionWithDestinationAndSource.cs
@@ -98,7 +98,7 @@ namespace XSharp.Assembler.x86
                 aOutput.Write(destination);
                 string source = this.GetSourceAsString();
                 if (!(SourceEmpty && source.Equals(""))){
-                    aOutput.Write(", ");
+                    aOutput.Write(aAssembler.Separator);
                     aOutput.Write(source);
                  }
             }

--- a/source/XSharp/XSharp/Assembler/Gen1/x86/_Infra/InstructionWithDestinationAndSourceAndArgument.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/x86/_Infra/InstructionWithDestinationAndSourceAndArgument.cs
@@ -92,12 +92,12 @@ namespace XSharp.Assembler.x86
                 aOutput.Write(destination);
                 string source = this.GetSourceAsString();
                 if (!(SourceEmpty && source.Equals(""))){
-                    aOutput.Write(", ");
+                    aOutput.Write(aAssembler.Separator);
                     aOutput.Write(source);
 					string argument = this.GetArgumentAsString();
 					if (!(ArgumentEmpty && argument.Equals("")))
 					{
-						aOutput.Write(", ");
+						aOutput.Write(aAssembler.Separator);
 						aOutput.Write(argument);
 					}
                  }

--- a/source/XSharp/XSharp/Assembler/Gen1/x86/_Infra/InstructionWithDestinationAndSourceAndSize.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/x86/_Infra/InstructionWithDestinationAndSourceAndSize.cs
@@ -6,7 +6,7 @@ namespace XSharp.Assembler.x86
         IInstructionWithSize
     {
         // todo: do all instructions with two operands have a size?
-        //todo should validate Instructions or use a constructor and no set properties. 
+        //todo should validate Instructions or use a constructor and no set properties.
         protected byte mSize;
 
         public InstructionWithDestinationAndSourceAndSize()
@@ -82,7 +82,7 @@ namespace XSharp.Assembler.x86
 
                 aOutput.Write(" ");
                 aOutput.Write(this.GetDestinationAsString());
-                aOutput.Write(", ");
+                aOutput.Write(aAssembler.Separator);
 
                 if (SourceIsIndirect)
                 {

--- a/source/XSharp/XSharp/Assembler/Gen1/x86/x87/FloatConditionalMove.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/x86/x87/FloatConditionalMove.cs
@@ -40,7 +40,7 @@
             }
             aOutput.Write(" ");
             aOutput.Write("ST0");
-            aOutput.Write(", ");
+            aOutput.Write(aAssembler.Separator);
             aOutput.Write(this.GetSourceAsString());
         }
     }

--- a/source/XSharp/XSharp/Gen1/XS.cs
+++ b/source/XSharp/XSharp/Gen1/XS.cs
@@ -13,6 +13,8 @@ namespace XSharp
     [SuppressMessage("Usage", "CA1806:Do not ignore method results")]
     public static partial class XS
     {
+        public static bool AllowComments = true;
+
         public static void Label(string labelName)
         {
             new Label(labelName);
@@ -653,7 +655,10 @@ namespace XSharp
 
         public static void Comment(string comment)
         {
-            new Comment(comment);
+            if (AllowComments)
+            {
+                new Comment(comment);
+            }
         }
 
         public static void Call(string target)


### PR DESCRIPTION
This PR adds the option to disable formatting/indentation (which is disabled by default now), as well as a static field in XS.cs for enabling/disabling comments (they are enabled by default). This can greatly reduce the time needed to assemble a file if all of those are disabled.