### PR TITLE
Allow for external binary inclusion using incbin assembler directive

### DIFF
--- a/source/XSharp/XSharp/Assembler/Gen1/DataMember.cs
+++ b/source/XSharp/XSharp/Assembler/Gen1/DataMember.cs
@@ -21,6 +21,7 @@ namespace XSharp.Assembler
         private string Size;
         private string StringValue;
         private Type Type;
+        private bool isIncBin;
 
         // Hack for not to emit raw data. See RawAsm
         public DataMember()
@@ -28,8 +29,10 @@ namespace XSharp.Assembler
             Name = "Dummy";
         }
 
-        public DataMember(string aName, string aValue, bool noConvert = false)
+        public DataMember(string aName, string aValue, bool noConvert = false, bool isIncBin = false)
         {
+            this.isIncBin = isIncBin;
+
             if (noConvert)
             {
                 Name = aName;
@@ -151,6 +154,13 @@ namespace XSharp.Assembler
             if (RawAsm != null)
             {
                 aOutput.WriteLine(RawAsm);
+                return;
+            }
+
+            if(isIncBin) {
+                aOutput.Write(Name);
+                aOutput.WriteLine(":");
+                aOutput.WriteLine("incbin \"" + StringValue + "\"");
                 return;
             }
 

--- a/source/XSharp/XSharp/Gen1/XS.cs
+++ b/source/XSharp/XSharp/Gen1/XS.cs
@@ -686,6 +686,10 @@ namespace XSharp
             Assembler.Assembler.CurrentInstance.DataMembers.Add(new DataMember(name, value));
         }
 
+        public static void DataMember(string name, string value, bool isIncBin) {
+            Assembler.Assembler.CurrentInstance.DataMembers.Add(new DataMember(name, value, true, isIncBin));
+        }
+
         public static void DataMemberBytes(string name, byte[] value)
         {
             Assembler.Assembler.CurrentInstance.DataMembers.Add(new DataMember(name, value));


### PR DESCRIPTION
Allows to use the incbin assembler directive supported in NASM & YASM to include big raw binary data